### PR TITLE
Fixed a crash when metadata keys had no value

### DIFF
--- a/value-similarity.py
+++ b/value-similarity.py
@@ -6,15 +6,15 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 #
 
 import tika
@@ -44,7 +44,7 @@ Options:
 	compare similarity of given files
 
 -h --help
-	show help on the screen	
+	show help on the screen
 '''
 
 def verboseLog(message):
@@ -71,7 +71,7 @@ def main(argv = None):
 			raise _Usage(_helpMessage)
 
 		dirFile = ""
-		filenames = []		
+		filenames = []
 		filename_list = []
 
 		for option, value in opts:
@@ -79,7 +79,7 @@ def main(argv = None):
 				raise _Usage(_helpMessage)
 
 			elif option in ('-c', '--file'):
-				
+
 				#extract file names from command line
 				if '-c' in argv :
 					index_of_file_option = argv.index('-c')
@@ -95,15 +95,15 @@ def main(argv = None):
 				_verbose = True
 
 		#format filename
-		filenames = [x.strip() for x in filenames]		
-		filenames = [filenames[k].strip('\'\n') for k in range(len(filenames))]		
-		for filename in filenames :		
-			if not os.path.isfile(os.path.join(dirFile, filename)):		
-				continue		
-			filename = os.path.join(dirFile, filename) if dirFile else filename		
-			filename_list.append(filename)		
+		filenames = [x.strip() for x in filenames]
+		filenames = [filenames[k].strip('\'\n') for k in range(len(filenames))]
+		for filename in filenames :
+			if not os.path.isfile(os.path.join(dirFile, filename)):
+				continue
+			filename = os.path.join(dirFile, filename) if dirFile else filename
+			filename_list.append(filename)
 
-		if len(filename_list) <2 :		
+		if len(filename_list) <2 :
 			raise _Usage("you need to type in at least two valid files")
 
 		union_feature_names = set()
@@ -119,8 +119,8 @@ def main(argv = None):
 				file_metadata[filename] = parsedData["metadata"]
 
 			#get key : value of metadata
-			for key in parsedData["metadata"].keys() :
-				value = parsedData["metadata"].get(key)[0]
+			for key, value in parsedData["metadata"].iteritems() :
+				
 				if isinstance(value, list):
 					value = ""
 					for meta_value in parsedData["metadata"].get(key)[0]:
@@ -138,11 +138,11 @@ def main(argv = None):
 		# now compute the specific resemblance and containment scores
 		for filename in file_parsed_data.keys():
 			overlap = {}
-			overlap = file_parsed_data[filename] & set(union_feature_names) 
+			overlap = file_parsed_data[filename] & set(union_feature_names)
 			resemblance_scores[filename] = float(len(overlap))/total_num_features
 
 		sorted_resemblance_scores = sorted(resemblance_scores.items(), key=operator.itemgetter(1), reverse=True)
-		
+
 		'''print "Resemblance:\n"
 		for tuple in sorted_resemblance_scores:
 			print os.path.basename(tuple[0].rstrip(os.sep))+","+str(tuple[1]) +"," + tuple[0] + ","+ convertUnicode(file_metadata[tuple[0]])+'\n'''
@@ -164,14 +164,8 @@ def convertUnicode( fileDict ) :
 		if isinstance(value, unicode) :
 			value = value.encode('utf-8').strip()
 		fileUTFDict[key] = value
-		
+
 	return str(fileUTFDict)
 
 if __name__ == "__main__":
 	sys.exit(main())
-
-
-
-
-
-	 


### PR DESCRIPTION
Line: `value = parsedData["metadata"].get(key)[0]` threw an exception when the key had no value. 
Modified `for key in parsedData["metadata"].keys() :` to `for key, value in parsedData["metadata"].iteritems() :` to handle that. 