### PR TITLE
accept specific mime types 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ You can also check out [ETLlib](https://github.com/chrismattmann/etllib/tree/mas
 How to use
 ===
 
+Optional: Compute similarity only on specific IANA MIME Type(s) inside a directory using **--accept**
+
 Key-based comparison
 --------------------
 This compares metadata feature names as a golden feature set
 ```
 #!/usr/bin/env python2.7
-python similarity.py -f [directory of files] or 
+python similarity.py -f [directory of files] [--accept [jpeg pdf etc...]]
+or 
 python similarity.py -c [file1 file2 file3 ...]
 ```
 Value-based comparison
@@ -34,7 +37,8 @@ Value-based comparison
 This compares metadata feature names together with its value as a golden feature set
 ```
 #!/usr/bin/env python2.7
-python value-similarity.py -f [directory of files] or 
+python value-similarity.py -f [directory of files] [--accept [jpeg pdf etc...]]
+or 
 python value-similarity.py -c [file1 file2 file3 ...]
 ```
 

--- a/cluster-scores.py
+++ b/cluster-scores.py
@@ -24,7 +24,7 @@ except ImportError:
 
 import sys
 
-default_threshold = 0.001
+default_threshold = 0.01
 
 usage = "Usage: python cluster-scores.py [-t threshold_value]"
 

--- a/similarity.py
+++ b/similarity.py
@@ -38,10 +38,13 @@ Options:
 	Work verbosely rather than silently.
 
 -f, --directory [path to directory]
-	read .jpg file from this directory
+	read files from this directory recursively
 
 -c, --file [file1 file2]
 	compare similarity of given files
+
+--accept [jpeg pdf etc...]
+	Optional: compute similarity only on specified IANA MIME Type(s)
 
 -h --help
 	show help on the screen
@@ -63,7 +66,7 @@ def main(argv = None):
 
 	try:
 		try:
-			opts, args = getopt.getopt(argv[1:], 'hvf:c:', ['help', 'verbose', 'directory=', 'file=' ])
+			opts, args = getopt.getopt(argv[1:], 'hvf:c:a:', ['help', 'verbose', 'directory=', 'file=', 'accept=' ])
 		except getopt.error, msg:
 			raise _Usage(msg)
 
@@ -73,6 +76,7 @@ def main(argv = None):
 		dirFile = ""
 		filenames = []
 		filename_list = []
+		allowed_mime_types = []
 		directory_flag = 0
 
 		for option, value in opts:
@@ -95,6 +99,11 @@ def main(argv = None):
 					for filename in files:
 						if not filename.startswith('.'):							
 							filename_list.append(os.path.join(root, filename))
+
+			elif option in ('--accept'):
+				#extract accepted mime types from command line
+				index_of_mime_type_option = argv.index('--accept')
+				allowed_mime_types = argv[index_of_mime_type_option+1 : ]
 		
 			elif option in ('-v', '--verbose'):
 				global _verbose
@@ -110,9 +119,14 @@ def main(argv = None):
 				filename = os.path.join(dirFile, filename) if dirFile else filename
 				filename_list.append(filename)
 
-
 		if len(filename_list) <2 :
 			raise _Usage("you need to type in at least two valid files")
+
+		#allow only files with specifed mime types
+		if len(allowed_mime_types) != 0:
+			filename_list = [filename for filename in filename_list if parser.from_file(filename) and str(parser.from_file(filename)['metadata']['Content-Type'].encode('utf-8')).split('/')[-1] in allowed_mime_types]
+		else:
+			print "Accepting all MIME Types....."
 
 		union_feature_names = set()
 		file_parsed_data = {}


### PR DESCRIPTION
@chrismattmann 

This PR implements an optional command line argument **--accept**, to compute similarity only on specified IANA MIME Type(s) inside a directory

If **--accept** is Not specified, tika-similarity defaults to computing scores over all mime types in a directory like before

This feature is **N/A** when comparing files on the command line using -c, --file [file1 file2]

Thank you!