### PR TITLE
Handling case where there is a space in the filename

### DIFF
--- a/edit-cosine-circle-packing.py
+++ b/edit-cosine-circle-packing.py
@@ -31,23 +31,24 @@ def createCluster(inputCSV,argNum):
 
     csvPath = inputCSV          #Input Path to csv file
     with open(csvPath,"r") as f:
-        lines = csv.reader(f.read().splitlines(), delimiter=' ')
+        # handling case where file names have space in between them
+        lines = [line.strip() for line in f]
         for line in lines:
             row.append(line)
 
     data={}
     for i in range(len(row)):
-        if "x-coordinate" in row[i][0].split(","):
+        if "x-coordinate" in row[i].split(","):
             continue
         else:
-            column = row[i][0].split(",")
+            column = row[i].split(",")
             data[column[argNum]]=[]         #Cluster based on the argument number passed
 
     for i in range(len(row)):
-        if "x-coordinate" in row[i][0].split(","):
+        if "x-coordinate" in row[i].split(","):
             continue
         else:
-            column = row[i][0].split(",")
+            column = row[i].split(",")
             second={}
             second["name"]=column[1]+"  "+column[2]
             second["size"]=column[2]

--- a/edit-cosine-cluster.py
+++ b/edit-cosine-cluster.py
@@ -32,23 +32,23 @@ def createCluster(inputCSV,argNum):
 
     csvPath = inputCSV          #Input Path to csv file
     with open(csvPath,"r") as f:
-        lines = csv.reader(f.read().splitlines(), delimiter=' ')
+        lines = [line.strip() for line in f]
         for line in lines:
             row.append(line)
 
     data={}
     for i in range(len(row)):
-        if "x-coordinate" in row[i][0].split(","):
+        if "x-coordinate" in row[i].split(","):
             continue
         else:
-            column = row[i][0].split(",")
+            column = row[i].split(",")
             data[column[argNum]]=[]         #Cluster based on the argument number passed
 
     for i in range(len(row)):
-        if "x-coordinate" in row[i][0].split(","):
+        if "x-coordinate" in row[i].split(","):
             continue
         else:
-            column = row[i][0].split(",")
+            column = row[i].split(",")
             second={}
             second["name"]=column[1]+"  "+column[2]
             second["size"]=column[2]


### PR DESCRIPTION
Json generation using "edit-cosine-cluster" and "edit-cosine-circle-packing" fails when file names in the directory has a space in between the name. Made modifications to fix the same.