### PR TITLE
Added support for JSON file input through inputFile argument.

### DIFF
--- a/cosine_similarity.py
+++ b/cosine_similarity.py
@@ -22,7 +22,7 @@ from vector import Vector
 import os, itertools, argparse, csv
 from requests import ConnectionError
 from time import sleep
-import ast
+import json
 
 def filterFiles(inputDir, acceptTypes):
     filename_list = []
@@ -71,7 +71,7 @@ def computeScores(inputDir, outCSV, acceptTypes):
                 continue
 
 '''
-Takes an input file and generates similarity scores for all combinations of row entries.
+Takes an input JSON file and generates similarity scores for all combinations of row entries.
 '''
 def computeScores2(inputFile, outCSV):
     with open(outCSV, "wb") as outF:
@@ -79,7 +79,7 @@ def computeScores2(inputFile, outCSV):
         a.writerow(["x-coordinate", "y-coordinate", "Similarity_score"])
 
         file1_parsedData = parser.from_file(inputFile)
-        row_list = ast.literal_eval(file1_parsedData["content"])
+        row_list = json.loads(file1_parsedData["content"])
 
         rows_tuple = itertools.combinations(row_list, 2)
         for row1, row2 in rows_tuple:

--- a/edit-value-similarity.py
+++ b/edit-value-similarity.py
@@ -27,7 +27,7 @@ def stringify(attribute_value):
     if isinstance(attribute_value, list):
         return str((", ".join(attribute_value)).encode('utf-8').strip())
     else:
-        return str(attribute_value.encode('utf-8').strip())
+        return str(str(attribute_value).encode('utf-8').strip())
 
 
 def computeScores(inputDir, outCSV, acceptTypes, allKeys):
@@ -168,18 +168,19 @@ def compute_score2(json_input_list, outCSV, acceptTypes, allKeys):
                 continue
     return
 
-def compute_scores(json_file, outCSV, acceptTypes, json_key, allKeys):
+def compute_scores(json_file, outCSV, acceptTypes, allKeys):
     na_metadata = ["resourceName"]
     with open(outCSV, "wb") as outF:
         a = csv.writer(outF, delimiter=',')
         a.writerow(["x-coordinate","y-coordinate","Similarity_score"])
 
         json_list = []
+        
         with open(json_file) as json_input_file:
-                json_list.extend(json.load(json_input_file)[json_key])
+                json_list.extend(json.load(json_input_file)[:])
         #json_list has list of JSON objects read from json file
 
-        print(len(json_list))
+        #print(len(json_list))
         metadata_dict = {}
         for entry in json_list:
             metadata_dict[entry['id']]=entry
@@ -239,13 +240,12 @@ if __name__ == "__main__":
     argParser.add_argument('--json', nargs='+', required=False, help='several paths to  JSON file containing certain metadata')
     argParser.add_argument('--accept', nargs='+', type=str, help='Optional: compute similarity only on specified IANA MIME Type(s)')
     argParser.add_argument('--allKeys', action='store_true', help='compute edit distance across all keys')
-    argParser.add_argument('--fileInput',required=False, help='Set to 1 to compute edit distance for JSON objects in the file')
-    argParser.add_argument('--jsonKey',required=False, help='JSON object list key')
+    argParser.add_argument('--inputFile', required=False, help='path to file')
     
     args = argParser.parse_args()
     
-    if args.fileInput=='1' and args.json and args.jsonKey:
-        compute_scores(args.json[0],args.outCSV, args.accept,args.jsonKey, args.allKeys)
+    if args.inputFile and args.outCSV:
+        compute_scores(args.inputFile, args.outCSV, args.accept, args.allKeys)
     elif args.inputDir and args.outCSV:
         computeScores(args.inputDir, args.outCSV, args.accept, args.allKeys)
     else:

--- a/jaccard_similarity.py
+++ b/jaccard_similarity.py
@@ -20,7 +20,11 @@
 # Computing pairwise jaccard similarity for a given directory of files
 
 from tika import parser
+from vector import Vector
 import os, itertools, argparse, csv
+from requests import ConnectionError
+from time import sleep
+import json
 
 def filterFiles(inputDir, acceptTypes):
     filename_list = []
@@ -61,14 +65,40 @@ def computeScores(inputDir, outCSV, acceptTypes):
 
         a.writerow([file1, file2, jaccard])
 
+def computeScores2(inputFile, outCSV):
+    with open(outCSV, "wb") as outF:
+        a = csv.writer(outF, delimiter=',')
+        a.writerow(["x-coordinate", "y-coordinate", "Similarity_score"])
+
+        file1_parsedData = parser.from_file(inputFile)
+        row_list = json.loads(file1_parsedData["content"])
+
+        rows_tuple = itertools.combinations(row_list, 2)
+        for row1, row2 in rows_tuple:
+
+            try:                
+                isCoExistant = lambda k: (k in row2) and (row1[k] == row2[k])
+                intersection = reduce(lambda m, k: (m + 1) if isCoExistant(k) else m, row1.keys(), 0)
+                
+                union = len(row1.keys()) + len(row2.keys()) - intersection
+                jaccard = float(intersection) / union
+
+                a.writerow([row_list.index(row1), row_list.index(row2), jaccard])
+            except ConnectionError:
+                sleep(1)
+            except KeyError:
+                continue
 
 if __name__ == "__main__":
 
     argParser = argparse.ArgumentParser('Jaccard similarity based file metadata')
-    argParser.add_argument('--inputDir', required=True, help='path to directory containing files')
+    argParser.add_argument('--inputFile', required=False, help='path to file')
+    argParser.add_argument('--inputDir', required=False, help='path to directory containing files')
     argParser.add_argument('--outCSV', required=True, help='path to directory for storing the output CSV File, containing pair-wise Jaccard similarity Scores')
     argParser.add_argument('--accept', nargs='+', type=str, help='Optional: compute similarity only on specified IANA MIME Type(s)')
     args = argParser.parse_args()
 
     if args.inputDir and args.outCSV:
         computeScores(args.inputDir, args.outCSV, args.accept)
+    if args.inputFile and args.outCSV:
+        computeScores2(args.inputFile, args.outCSV)

--- a/vector.py
+++ b/vector.py
@@ -23,7 +23,7 @@ def stringify(attribute_value):
     if isinstance(attribute_value, list):
         return str((", ".join(attribute_value)).encode('utf-8').strip())
     else:
-        return str(attribute_value.encode('utf-8').strip())
+        return str(str(attribute_value).encode('utf-8').strip())
 
 
 class Vector:


### PR DESCRIPTION
Took the computeScores2 method from cosine_similarity.py (which takes in an input file of JSON objects) and extended those to the jaccard_similarity.py and edit-value-similarity.py. The edit-value one slightly different syntax than the others, so it was a bit trickier to implement.

e.g. Now can run:
py -2 jaccard_similarity.py --fileInput json_to_input.json --outCSV test_output.csv