### PR TITLE
Allow json metadata file input with arg: --jsonDir /path/to/json/dir. New circle-packing-for-all viz.

### DIFF
--- a/circle-packing-for-all.py
+++ b/circle-packing-for-all.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python2.7
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+import json
+import argparse
+import csv
+import sys
+
+
+def createCluster(inputCSV,argNum):
+    row=[]
+    if(argNum not in [0,1,2]):
+        print("Input Error! \nPass argument to --cluster as one of the following\n0 for clustering based on x-coordinate, \n1 for clustering based on y-coordinate, \n2 for clustering based on similarity score")
+        sys.exit()
+
+    csvPath = inputCSV          #Input Path to csv file
+    with open(csvPath,"r") as f:
+        lines = [line.strip() for line in f]
+        standard = lines[1].split(",")[0]
+        row.append("{0},{0},1".format(standard))
+        for line in lines:
+            if not "x-coordinate" in line.split(","):
+                if standard in line.split(","):
+                    line_split = line.split(",")
+                    line_split[2] = str(round(float(line_split[2]), 2))
+                    line = ",".join(line_split)
+                    row.append(line)
+
+    data={}
+    for i in range(len(row)):
+        if "x-coordinate" in row[i].split(","):
+            continue
+        else:
+            column = row[i].split(",")
+            data[column[argNum]]=[]         #Cluster based on the argument number passed
+
+    for i in range(len(row)):
+        if "x-coordinate" in row[i].split(","):
+            continue
+        else:
+            column = row[i].split(",")
+            second={}
+            second["name"]=column[1].split("/")[-1]+"  "+column[2]
+            second["size"]=column[2]
+            data[column[argNum]].append(second)          #Cluster based on the argument number passed
+            
+    clusterList = []
+    i=0
+    for elem in list(data.keys()):
+        first={}
+        first["name"]="cluster "+str(i)
+        first["children"]=data[elem]
+        clusterList.append(first)
+        i+=1
+
+
+    print(json.dumps(clusterList, sort_keys=True, indent=4, separators=(',', ': ')))
+
+    clusterStruct = {"name":"clusters", "children":clusterList}
+    with open("circle.json", "w") as f:             #Pass the json file as input to circle-packing.html
+        f.write(json.dumps(clusterStruct, sort_keys=True, indent=4, separators=(',', ': ')))
+
+if __name__ == '__main__':
+    argParser = argparse.ArgumentParser('Edit/Cosine/Jaccard JSON Similarity Circle Packing')
+    argParser.add_argument('--inputCSV', required=True, help='path to directory containing CSV File, containing pair-wise similarity scores based on edit/cosine similarity distance')
+    argParser.add_argument('--cluster', required=True, type=int, help='Cluster based on the x-coordinate/y-coordinate/similarity score. Pass 0 for clustering based on x-coordinate, 1 for clustering based on y-coordinate, 2 for clustering based on similarity score')
+    args = argParser.parse_args()
+
+    createCluster(args.inputCSV, args.cluster)

--- a/cosine_similarity.py
+++ b/cosine_similarity.py
@@ -19,10 +19,12 @@
 
 from tika import parser
 from vector import Vector
+import json
 import os, itertools, argparse, csv
 from requests import ConnectionError
 from time import sleep
 import ast
+
 
 def filterFiles(inputDir, acceptTypes):
     filename_list = []
@@ -37,7 +39,9 @@ def filterFiles(inputDir, acceptTypes):
     except ConnectionError:
         sleep(1)
     if acceptTypes:
-        filename_list = [filename for filename in filename_list if str(parser.from_file(filename)['metadata']['Content-Type'].encode('utf-8').decode('utf-8')).split('/')[-1] in acceptTypes]
+        filename_list = [filename for filename in filename_list if str(
+            parser.from_file(filename)['metadata']['Content-Type'].encode('utf-8').decode('utf-8')).split('/')[
+            -1] in acceptTypes]
     else:
         print("Accepting all MIME Types.....")
 
@@ -45,34 +49,83 @@ def filterFiles(inputDir, acceptTypes):
 
 
 def computeScores(inputDir, outCSV, acceptTypes):
-    
     with open(outCSV, "wb") as outF:
         a = csv.writer(outF, delimiter=',')
-        a.writerow(["x-coordinate","y-coordinate","Similarity_score"])        
+        a.writerow(["x-coordinate", "y-coordinate", "Similarity_score"])
 
         files_tuple = itertools.combinations(filterFiles(inputDir, acceptTypes), 2)
         for file1, file2 in files_tuple:
             try:
                 row_cosine_distance = [file1, file2]
-            
+
                 file1_parsedData = parser.from_file(file1)
                 file2_parsedData = parser.from_file(file2)
-           
+
                 v1 = Vector(file1, file1_parsedData["metadata"])
                 v2 = Vector(file2, file2_parsedData["metadata"])
-            
 
-                row_cosine_distance.append(v1.cosTheta(v2))            
+                row_cosine_distance.append(v1.cosTheta(v2))
 
-                a.writerow(row_cosine_distance)  
+                a.writerow(row_cosine_distance)
             except ConnectionError:
                 sleep(1)
             except KeyError:
                 continue
 
+
+def computeScoresJson(inputDir, outCSV, acceptTypes):
+    with open(outCSV, "w") as outF:
+        a = csv.writer(outF, delimiter=',')
+        a.writerow(["x-coordinate", "y-coordinate", "Similarity_score"])
+
+        files_tuple = itertools.combinations(filterFiles(inputDir, acceptTypes), 2)
+        for file1, file2 in files_tuple:
+            if not file1.endswith('json'):
+                continue
+            if not file2.endswith('json'):
+                continue
+            try:
+                row_cosine_distance = [file1, file2]
+                with open(file1, 'r') as f1:
+                    file1_parsedData = json.load(f1)
+                    if type(file1_parsedData) == dict:
+                        for k, v in file1_parsedData.items():
+                            file1_parsedData[k] = str(v)
+                    elif type(file1_parsedData) == list:
+                        file1_metadata = file1_parsedData
+                        file1_parsedData = {}
+                        for item in file1_metadata:
+                            for k, v in item.items():
+                                file1_parsedData[k] = str(v)
+                with open(file2, 'r') as f2:
+                    file2_parsedData = json.load(f2)
+                    if type(file2_parsedData) == dict:
+                        for k, v in file2_parsedData.items():
+                            file2_parsedData[k] = str(v)
+                    elif type(file2_parsedData) == list:
+                        file2_metadata = file2_parsedData
+                        file2_parsedData = {}
+                        for item in file2_metadata:
+                            for k, v in item.items():
+                                file2_parsedData[k] = str(v)
+
+                v1 = Vector(file1, file1_parsedData)
+                v2 = Vector(file2, file2_parsedData)
+
+                row_cosine_distance.append(v1.cosTheta(v2))
+
+                a.writerow(row_cosine_distance)
+            except ConnectionError:
+                sleep(1)
+            except KeyError:
+                continue
+
+
 '''
 Takes an input file and generates similarity scores for all combinations of row entries.
 '''
+
+
 def computeScores2(inputFile, outCSV):
     with open(outCSV, "wb") as outF:
         a = csv.writer(outF, delimiter=',')
@@ -104,11 +157,16 @@ if __name__ == "__main__":
     argParser = argparse.ArgumentParser('Cosine similarity based on Metadata values')
     argParser.add_argument('--inputFile', required=False, help='path to file')
     argParser.add_argument('--inputDir', required=False, help='path to directory containing files')
-    argParser.add_argument('--outCSV', required=True, help='path to directory for storing the output CSV File, containing pair-wise Cosine similarity Scores')
-    argParser.add_argument('--accept', nargs='+', type=str, help='Optional: compute similarity only on specified IANA MIME Type(s)')
+    argParser.add_argument('--jsonDir', required=False, help='path to directory containing all the json metadata files')
+    argParser.add_argument('--outCSV', required=True,
+                           help='path to directory for storing the output CSV File, containing pair-wise Cosine similarity Scores')
+    argParser.add_argument('--accept', nargs='+', type=str,
+                           help='Optional: compute similarity only on specified IANA MIME Type(s)')
     args = argParser.parse_args()
 
     if args.inputDir and args.outCSV:
         computeScores(args.inputDir, args.outCSV, args.accept)
+    if args.jsonDir and args.outCSV:
+        computeScoresJson(args.jsonDir, args.outCSV, args.accept)
     if args.inputFile and args.outCSV:
         computeScores2(args.inputFile, args.outCSV)

--- a/jaccard_similarity.py
+++ b/jaccard_similarity.py
@@ -20,8 +20,10 @@
 # Computing pairwise jaccard similarity for a given directory of files
 
 from tika import parser
+import json
 import os, itertools, argparse, csv
 from functools import reduce
+
 
 def filterFiles(inputDir, acceptTypes):
     filename_list = []
@@ -34,7 +36,9 @@ def filterFiles(inputDir, acceptTypes):
 
     filename_list = [filename for filename in filename_list if parser.from_file(filename)]
     if acceptTypes:
-        filename_list = [filename for filename in filename_list if str(parser.from_file(filename)['metadata']['Content-Type'].encode('utf-8').decode('utf-8')).split('/')[-1] in acceptTypes]
+        filename_list = [filename for filename in filename_list if str(
+            parser.from_file(filename)['metadata']['Content-Type'].encode('utf-8').decode('utf-8')).split('/')[
+            -1] in acceptTypes]
     else:
         print("Accepting all MIME Types.....")
 
@@ -63,13 +67,62 @@ def computeScores(inputDir, outCSV, acceptTypes):
         a.writerow([file1, file2, jaccard])
 
 
+def computeScoresJson(inputDir, outCSV, acceptTypes):
+    with open(outCSV, "w") as outF:
+        a = csv.writer(outF, delimiter=',')
+        a.writerow(["x-coordinate", "y-coordinate", "Similarity_score"])
+
+        files_tuple = itertools.combinations(filterFiles(inputDir, acceptTypes), 2)
+
+        for file1, file2 in files_tuple:
+            if not file1.endswith('json'):
+                continue
+            if not file2.endswith('json'):
+                continue
+            with open(file1, 'r') as f1:
+                f1MetaData = json.load(f1)
+                if type(f1MetaData) == dict:
+                    for k, v in f1MetaData.items():
+                        f1MetaData[k] = str(v)
+                elif type(f1MetaData) == list:
+                    file1_metadata = f1MetaData
+                    f1MetaData = {}
+                    for item in file1_metadata:
+                        for k, v in item.items():
+                            f1MetaData[k] = str(v)
+            with open(file2, 'r') as f2:
+                f2MetaData = json.load(f2)
+                if type(f2MetaData) == dict:
+                    for k, v in f2MetaData.items():
+                        f2MetaData[k] = str(v)
+                elif type(f2MetaData) == list:
+                    file2_metadata = f2MetaData
+                    f2MetaData = {}
+                    for item in file2_metadata:
+                        for k, v in item.items():
+                            f2MetaData[k] = str(v)
+
+            isCoExistant = lambda k: (k in f2MetaData) and (f1MetaData[k] == f2MetaData[k])
+            intersection = reduce(lambda m, k: (m + 1) if isCoExistant(k) else m, list(f1MetaData.keys()), 0)
+
+            union = len(list(f1MetaData.keys())) + len(list(f2MetaData.keys())) - intersection
+            jaccard = float(intersection) / union
+
+            a.writerow([file1, file2, jaccard])
+
+
 if __name__ == "__main__":
 
     argParser = argparse.ArgumentParser('Jaccard similarity based file metadata')
-    argParser.add_argument('--inputDir', required=True, help='path to directory containing files')
-    argParser.add_argument('--outCSV', required=True, help='path to directory for storing the output CSV File, containing pair-wise Jaccard similarity Scores')
-    argParser.add_argument('--accept', nargs='+', type=str, help='Optional: compute similarity only on specified IANA MIME Type(s)')
+    argParser.add_argument('--inputDir', required=False, help='path to directory containing files')
+    argParser.add_argument('--jsonDir', required=False, help='path to directory containing all the json metadata files')
+    argParser.add_argument('--outCSV', required=True,
+                           help='path to directory for storing the output CSV File, containing pair-wise Jaccard similarity Scores')
+    argParser.add_argument('--accept', nargs='+', type=str,
+                           help='Optional: compute similarity only on specified IANA MIME Type(s)')
     args = argParser.parse_args()
 
     if args.inputDir and args.outCSV:
         computeScores(args.inputDir, args.outCSV, args.accept)
+    if args.jsonDir and args.outCSV:
+        computeScoresJson(args.jsonDir, args.outCSV, args.accept)


### PR DESCRIPTION
Allow .json metadata file input for edit-value-similarity, jaccard-similarity, cosine-similarity with arg: --jsonDir /path/to/json/dir . And add a circle-packing-for-all.py to visualize the new --jsonDir outputs. run python circle-packing-for-all.py --inputCSV /path/csv --cluster 2 to get circle.json. Then you can use python’s simplehttpserver to open up a localhost in the directory and go to http://localhost:8000/circlepacking.html to get visualization figure.